### PR TITLE
re-enable nav-ball toggle (speed mode)

### DIFF
--- a/AFBW/FlightManager.cs
+++ b/AFBW/FlightManager.cs
@@ -382,10 +382,7 @@ namespace KSPAdvancedFlyByWire
                     WarpController.StopWarp();
                     return;
                 case DiscreteAction.NavballToggle:
-                    if (MapView.MapIsEnabled && MapView.fetch != null)
-                    {
-                        //  MapView.fetch.maneuverModeToggle.OnPress.Invoke();
-                    }
+                    FlightGlobals.CycleSpeedModes();
                     return;
                 case DiscreteAction.IVAViewToggle:
                     if (CameraManager.Instance != null)


### PR DESCRIPTION
It looks like the action "NavballToggle" has been disabled for a while, likely because of a previous KSP API change. This PR re-implements this feature with the new API function.