### PR TITLE
New Feature: SAS Invert

### DIFF
--- a/AFBW/ControllerPreset.cs
+++ b/AFBW/ControllerPreset.cs
@@ -48,6 +48,7 @@ namespace KSPAdvancedFlyByWire
         RCS,
         SAS,
         SASHold,
+        SASInvert,
         SASStabilityAssist,
         SASPrograde,
         SASRetrograde,

--- a/AFBW/FlightManager.cs
+++ b/AFBW/FlightManager.cs
@@ -402,6 +402,9 @@ namespace KSPAdvancedFlyByWire
                 case DiscreteAction.SASHold:
                     FlightGlobals.ActiveVessel.ActionGroups.SetGroup(KSPActionGroup.SAS, true);
                     return;
+                case DiscreteAction.SASInvert:
+                    invertAutopilotMode();
+                    return;
                 case DiscreteAction.SASStabilityAssist:
                     setAutopilotMode(VesselAutopilot.AutopilotMode.StabilityAssist);
                     return;
@@ -732,6 +735,38 @@ namespace KSPAdvancedFlyByWire
                 return true;
             }
             return false;
+        }
+
+        private static bool invertAutopilotMode()
+        {
+            if (!FlightGlobals.ActiveVessel.Autopilot.Enabled)
+                return false;
+
+            switch (FlightGlobals.ActiveVessel.Autopilot.Mode)
+            {
+                case VesselAutopilot.AutopilotMode.StabilityAssist:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.Maneuver);
+                case VesselAutopilot.AutopilotMode.Maneuver:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.StabilityAssist);
+                case VesselAutopilot.AutopilotMode.Prograde:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.Retrograde);
+                case VesselAutopilot.AutopilotMode.Retrograde:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.Prograde);
+                case VesselAutopilot.AutopilotMode.Normal:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.Antinormal);
+                case VesselAutopilot.AutopilotMode.Antinormal:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.Normal);
+                case VesselAutopilot.AutopilotMode.RadialIn:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.RadialOut);
+                case VesselAutopilot.AutopilotMode.RadialOut:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.RadialIn);
+                case VesselAutopilot.AutopilotMode.Target:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.AntiTarget);
+                case VesselAutopilot.AutopilotMode.AntiTarget:
+                    return setAutopilotMode(VesselAutopilot.AutopilotMode.Target);
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/AFBW/FlightManager.cs
+++ b/AFBW/FlightManager.cs
@@ -403,42 +403,42 @@ namespace KSPAdvancedFlyByWire
                     FlightGlobals.ActiveVessel.ActionGroups.SetGroup(KSPActionGroup.SAS, true);
                     return;
                 case DiscreteAction.SASStabilityAssist:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.StabilityAssist, 0);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.StabilityAssist);
                     return;
                 case DiscreteAction.SASPrograde:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.Prograde, 1);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.Prograde);
                     return;
                 case DiscreteAction.SASRetrograde:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.Retrograde, 2);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.Retrograde);
                     return;
                 case DiscreteAction.SASNormal:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.Normal, 3);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.Normal);
                     return;
                 case DiscreteAction.SASAntinormal:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.Antinormal, 4);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.Antinormal);
                     return;
                 // The radial controls are reversed
                 case DiscreteAction.SASRadialOut:
                     //case DiscreteAction.SASRadialIn:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.RadialIn, 5);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.RadialIn);
                     return;
                 case DiscreteAction.SASRadialIn:
                     //case DiscreteAction.SASRadialOut:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.RadialOut, 6);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.RadialOut);
                     return;
                 case DiscreteAction.SASManeuver:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.Maneuver, 7);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.Maneuver);
                     return;
                 case DiscreteAction.SASTarget:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.Target, 8);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.Target);
                     return;
                 case DiscreteAction.SASAntiTarget:
-                    setAutopilotMode(VesselAutopilot.AutopilotMode.AntiTarget, 9);
+                    setAutopilotMode(VesselAutopilot.AutopilotMode.AntiTarget);
                     return;
                 case DiscreteAction.SASManeuverOrTarget:
-                    if (!setAutopilotMode(VesselAutopilot.AutopilotMode.Maneuver, 7))
+                    if (!setAutopilotMode(VesselAutopilot.AutopilotMode.Maneuver))
                     {
-                        setAutopilotMode(VesselAutopilot.AutopilotMode.Target, 8);
+                        setAutopilotMode(VesselAutopilot.AutopilotMode.Target);
                     };
                     return;
                 case DiscreteAction.TogglePrecisionControls:
@@ -721,13 +721,7 @@ namespace KSPAdvancedFlyByWire
             }
         }
 
-        private static void setSASUI(int mode)
-        {
-            KSP.UI.UIStateToggleButton[] SASbtns = UnityEngine.Object.FindObjectOfType<VesselAutopilotUI>().modeButtons;
-            SASbtns[mode].SetState(true);
-        }
-
-        private static bool setAutopilotMode(VesselAutopilot.AutopilotMode mode, int ui_button)
+        private static bool setAutopilotMode(VesselAutopilot.AutopilotMode mode)
         {
             //Debug.Log("setAutopilotMode, mode: " + mode);
             if (FlightGlobals.ActiveVessel.Autopilot.CanSetMode(mode))
@@ -735,13 +729,9 @@ namespace KSPAdvancedFlyByWire
                 FlightGlobals.ActiveVessel.ActionGroups.SetGroup(KSPActionGroup.SAS, true);
                 FlightGlobals.ActiveVessel.Autopilot.Update();
                 FlightGlobals.ActiveVessel.Autopilot.SetMode(mode);
-                setSASUI(ui_button);
                 return true;
             }
-            else
-            {
-                return false;
-            }
+            return false;
         }
     }
 }

--- a/AFBW/Stringify.cs
+++ b/AFBW/Stringify.cs
@@ -130,6 +130,8 @@
                     return "Camera View [Toggle]";
                 case DiscreteAction.SASHold:
                     return "SAS (Hold)";
+                case DiscreteAction.SASInvert:
+                    return "SAS (Invert)";
                 case DiscreteAction.SASStabilityAssist:
                     return "SAS (Stability assist)";
                 case DiscreteAction.SASPrograde:


### PR DESCRIPTION
This is a feature that I wanted to have for my setup, and thought others might as well.

The idea is that this action can be mapped to a button and, when pressed, will invert or reverse the current SAS setting. For example, if your SAS is currently set to Prograde, this action will toggle the SAS to Retrograde and back again to Prograde.

I find this beneficial, because it will allow me to access the eight directional SAS modes with five button mappings, rather than eight. 

Additionally, I noticed that the `setSASUI` function appears to be unnecessary. With the current KSP API, invoking `FlightGlobals.ActiveVessel.Autopilot.SetMode(mode)` will highlight the appropriate SAS radial button for you. This may not have always been the case, but I decided to delete that function as it currently seems redundant.