### PR TITLE
Add support for Custom Axis Groups

### DIFF
--- a/AFBW/ControllerPreset.cs
+++ b/AFBW/ControllerPreset.cs
@@ -136,7 +136,11 @@ namespace KSPAdvancedFlyByWire
         WheelThrottleTrim,
         CameraX,
         CameraY,
-        CameraZoom
+        CameraZoom,
+        Custom1,
+        Custom2,
+        Custom3,
+        Custom4,
     }
 
     public class DiscreteActionEntry

--- a/AFBW/Stringify.cs
+++ b/AFBW/Stringify.cs
@@ -225,6 +225,14 @@
                     return "Camera Y";
                 case ContinuousAction.CameraZoom:
                     return "Camera Zoom";
+                case ContinuousAction.Custom1:
+                    return "Custom Axis 1";
+                case ContinuousAction.Custom2:
+                    return "Custom Axis 2";
+                case ContinuousAction.Custom3:
+                    return "Custom Axis 3";
+                case ContinuousAction.Custom4:
+                    return "Custom Axis 4";
                 default:
                     return "Unknown Action";
             }

--- a/controller_test_tool/ControllerTestTool/ControllerPreset.cs
+++ b/controller_test_tool/ControllerTestTool/ControllerPreset.cs
@@ -115,7 +115,11 @@ namespace KSPAdvancedFlyByWire
         WheelThrottleTrim,
         CameraX,
         CameraY,
-        CameraZoom
+        CameraZoom,
+        Custom1,
+        Custom2,
+        Custom3,
+        Custom4,
     }
 
     public class ControllerPreset

--- a/controller_test_tool/ControllerTestTool/Stringify.cs
+++ b/controller_test_tool/ControllerTestTool/Stringify.cs
@@ -183,6 +183,14 @@
                     return "Camera Y";
                 case ContinuousAction.CameraZoom:
                     return "Camera zoom";
+                case ContinuousAction.Custom1:
+                    return "Custom Axis 1";
+                case ContinuousAction.Custom2:
+                    return "Custom Axis 2";
+                case ContinuousAction.Custom3:
+                    return "Custom Axis 3";
+                case ContinuousAction.Custom4:
+                    return "Custom Axis 4";
                 default:
                     return "Unknown action";
             }


### PR DESCRIPTION
This adds support for Custom Axis action groups.

It also allows the default axes to bind correctly to action groups in-game, which eliminates the need to use the keyboard as a workaround for such bind scenarios.

The implementation feeds the information forward through the `FlightCtrlState`, maintaining compatibility with any future changes of the base game that might rely on `FlightCtrlState.custom_axes`.

![image](https://user-images.githubusercontent.com/434942/176591230-3dfc6c59-4e77-4b4c-9103-dba5d4f9b40c.png)