### PR TITLE
Change libSDL2 to generic version on linux

### DIFF
--- a/AFBW/SDL2.cs
+++ b/AFBW/SDL2.cs
@@ -40,7 +40,7 @@ namespace SDL2
 		#region SDL2# Variables
 
 #if LINUX
-		private const string nativeLibName = "libSDL2-2.14";
+		private const string nativeLibName = "libSDL2";
 #elif OSX
 		private const string nativeLibName = "libSDL2-2.0.14";
 #else


### PR DESCRIPTION
This changes the libSDL2 version used to the generic "libSDL2", instead of "libSDL2-2.14". Using the specific version causes problems with systems that have another version installed or use a different naming conventions---for example my Gentoo system calls the library "libSDL2-2.0" (the installed version is actually libsdl2-2.28.5-r2). A similar patch for OSX might also be desirable, but I don't have anything to test that on.

For compatibility reasons, there is (almost) always a symbolic link to the library that does not include the version, allowing programs to use whatever version is available, even if they are linked against a different version---this is why this works better than giving a specific version.

Mat2ch suggested this patch on the forum thread for the mod:
https://forum.kerbalspaceprogram.com/topic/175359-112x-afbw-revived-joystick-controller-mod/?do=findComment&comment=4415081