### PR TITLE
Change libSDL2 to libSDL2-2.0.so.0

### DIFF
--- a/AFBW/SDL2.cs
+++ b/AFBW/SDL2.cs
@@ -40,7 +40,7 @@ namespace SDL2
 		#region SDL2# Variables
 
 #if LINUX
-		private const string nativeLibName = "libSDL2";
+		private const string nativeLibName = "libSDL2-2.0.so.0";
 #elif OSX
 		private const string nativeLibName = "libSDL2-2.0.14";
 #else


### PR DESCRIPTION
Addresses #36

It turns out that `libSDL2.so` is not present under all distros, but it appears that `libSDL2-2.0.so.0` is---this fixes the issue that @maxtimbo was facing on Pop! OS.

This might need some testing by other users, so I'm currently working on a branch that should have a working Makefile, but it does move some files around so I might not PR it.