### PR TITLE
Change libSDL2-2.0.14 to libSDL2-2.0.0 for osx

### DIFF
--- a/AFBW/SDL2.cs
+++ b/AFBW/SDL2.cs
@@ -42,7 +42,7 @@ namespace SDL2
 #if LINUX
 		private const string nativeLibName = "libSDL2-2.0.so.0";
 #elif OSX
-		private const string nativeLibName = "libSDL2-2.0.14";
+		private const string nativeLibName = "libSDL2-2.0.0";
 #else
 		private const string nativeLibName = "SDL2";
 #endif


### PR DESCRIPTION
This should provide better compatibility for OS X. The dylib is always named libSDL2-2.0.0.dylib regardless of version.