### PR TITLE
Fix discrete action release binding check

### DIFF
--- a/AFBW/AdvancedFlyByWire.cs
+++ b/AFBW/AdvancedFlyByWire.cs
@@ -491,7 +491,11 @@ namespace KSPAdvancedFlyByWire
             {
                 foreach (DiscreteAction action in actions)
                 {
-                    m_FlightManager.EvaluateDiscreteActionRelease(config, action, state);
+                    var binding = config.GetCurrentPreset().GetBitsetForDiscreteBinding(action);
+                    if (binding != null && binding.Get(button))
+                    {
+                        m_FlightManager.EvaluateDiscreteActionRelease(config, action, state);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Some controllers, like the Thrustmaster TCA Quadrant Airbus Edition, have on/off switches that map to buttons (the "on" position means the button stays pressed). I use these switches to enable SAS by binding the switch to SAS (hold) in AFBW. However, the current behavior releases the binding regardless of which button was released, so any button press, even an unrelated one, can disable SAS (hold) or any other hold binding.

This PR changes the behavior so the discrete action release fires only when the released button is part of the action binding.